### PR TITLE
feat: bootstrap compose for Agents (UI on :2496)

### DIFF
--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -17,6 +17,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    networks:
+      - agents_stack
 
   # LiteLLM Postgres database
   litellm-db:
@@ -34,6 +36,8 @@ services:
       timeout: 5s
       retries: 5
       start_period: 20s
+    networks:
+      - agents_stack
 
   # LiteLLM service
   litellm:
@@ -51,6 +55,8 @@ services:
     depends_on:
       litellm-db:
         condition: service_healthy
+    networks:
+      - agents_stack
 
   # Platform server (NestJS) — internal only, UI will proxy
   platform-server:
@@ -65,6 +71,7 @@ services:
       PORT: "3010"
       VAULT_ENABLED: 'true'
       VAULT_ADDR: http://vault:8200
+      VAULT_TOKEN: dev-root
     depends_on:
       platform-db:
         condition: service_healthy
@@ -76,6 +83,8 @@ services:
       - "3010"
     # Run DB migrations then start the server. Requires prisma CLI in the image (now included).
     command: ["/bin/sh", "-lc", "set -e; prisma migrate deploy --schema /opt/app/packages/platform-server/prisma/schema.prisma; exec tsx src/index.ts"]
+    networks:
+      - agents_stack
 
   # Platform UI reverse proxy — the only exposed service
   platform-ui:
@@ -88,6 +97,8 @@ services:
         condition: service_started
     ports:
       - "2496:80"
+    networks:
+      - agents_stack
 
   # HashiCorp Vault (dev mode) for secrets management — internal only
   vault:
@@ -101,6 +112,8 @@ services:
       - -dev
       - -dev-root-token-id=dev-root
       - -dev-listen-address=0.0.0.0:8200
+    networks:
+      - agents_stack
 
 networks:
   agents_stack:

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -114,7 +114,7 @@ services:
     restart: unless-stopped
     cap_add:
       - IPC_LOCK
-    environment:
+    environment: {}
     command:
       - server
       - -dev

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
       POSTGRES_PASSWORD: agents
       POSTGRES_DB: agents
     volumes:
-      - agents_pgdata:/var/lib/postgresql/data
+      - agyn_pgdata:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U agents -d agents"]
       interval: 10s
@@ -79,16 +79,20 @@ services:
       WORKSPACE_NETWORK_NAME: agents_stack
       CORS_ORIGINS: http://localhost:2496
       PORT: "3010"
+      VAULT_ENABLED: 'true'
+      VAULT_ADDR: http://vault:8200
+      VAULT_TOKEN: dev-root
     depends_on:
       agyn-db:
         condition: service_healthy
       litellm:
         condition: service_healthy
+      vault:
+        condition: service_started
     expose:
       - "3010"
     # Run DB migrations then start the server. Requires prisma CLI in the image (now included).
     command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"]
-
   # Platform UI reverse proxy — the only exposed service
   platform-ui:
     image: ghcr.io/hautechai/agents-platform-ui:latest
@@ -102,10 +106,30 @@ services:
     ports:
       - "2496:80"
 
+
+  vault:
+    image: hashicorp/vault:1.17
+    container_name: vault
+
+    restart: unless-stopped
+    cap_add:
+      - IPC_LOCK
+    environment:
+    command:
+      - server
+      - -dev
+      - -dev-root-token-id=dev-root
+      - -dev-listen-address=0.0.0.0:8200
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8200/v1/sys/health || (command -v curl >/dev/null 2>&1 && curl -fsS http://localhost:8200/v1/sys/health)"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
 networks:
   agents_stack:
     driver: bridge
 
 volumes:
-  agents_pgdata:
+  agyn_pgdata:
   litellm_pgdata:

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -86,8 +86,8 @@ services:
         condition: service_healthy
     expose:
       - "3010"
-    # NOTE: Once the server image includes Prisma CLI, uncomment the command below to run migrations before starting.
-    # command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"]
+    # Run DB migrations then start the server. Requires prisma CLI in the image (now included).
+    command: ["/bin/sh", "-lc", "prisma migrate deploy # command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"]# command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"] tsx src/index.ts"]
 
   # Platform UI reverse proxy — the only exposed service
   platform-ui:

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -65,7 +65,6 @@ services:
       PORT: "3010"
       VAULT_ENABLED: 'true'
       VAULT_ADDR: http://vault:8200
-      NODE_OPTIONS: --experimental-specifier-resolution=node
     depends_on:
       platform-db:
         condition: service_healthy
@@ -76,7 +75,7 @@ services:
     expose:
       - "3010"
     # Run DB migrations then start the server. Requires prisma CLI in the image (now included).
-    command: ["/bin/sh", "-lc", "set -e; prisma migrate deploy --schema /opt/app/packages/platform-server/prisma/schema.prisma; exec node --experimental-specifier-resolution=node dist/index.js"]
+    command: ["/bin/sh", "-lc", "set -e; prisma migrate deploy --schema /opt/app/packages/platform-server/prisma/schema.prisma; exec tsx src/index.ts"]
 
   # Platform UI reverse proxy — the only exposed service
   platform-ui:

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -76,34 +76,7 @@ services:
     expose:
       - "3010"
     # Run DB migrations then start the server. Requires prisma CLI in the image (now included).
-    command: ["/bin/sh", "-lc", "prisma migrate deploy --schema /opt/app/packages/platform-server/prisma/schema.prisma prisma migrate deploy && tsx src/index.tsprisma migrate deploy && tsx src/index.ts tsx src/index.ts"]
-
-  # Platform UI reverse proxy — the only exposed service
-  platform-ui:
-    image: ghcr.io/hautechai/agents-platform-ui:latest
-    restart: unless-stopped
-    environment:
-      API_UPSTREAM: http://platform-server:3010
-    depends_on:
-      platform-server:
-        condition: service_started
-    ports:
-      - "2496:80"
-
-  # HashiCorp Vault (dev mode) for secrets management — internal only
-  vault:
-    image: hashicorp/vault:1.17
-    restart: unless-stopped
-    cap_add:
-      - IPC_LOCK
-    environment: {}
-    command:
-      - server
-      - -dev
-      - -dev-root-token-id=dev-root
-      - -dev-listen-address=0.0.0.0:8200
-    healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8200/v1/sys/health || (command -v curl >/dev/null 2>&1 && curl -fsS http://localhost:8200/v1/sys/health)"]
+    command: ["/bin/sh", "-lc", "set -e; prisma migrate deploy --schema /opt/app/packages/platform-server/prisma/schema.prisma; exec tsx src/index.ts"]
       interval: 10s
       timeout: 3s
       retries: 5

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -51,16 +51,6 @@ services:
     depends_on:
       litellm-db:
         condition: service_healthy
-    healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "wget -qO- http://localhost:4000/health || wget -qO- http://localhost:4000/ui || wget -qO- http://localhost:4000/ || (command -v curl >/dev/null 2>&1 && curl -fsS http://localhost:4000/health)",
-        ]
-      interval: 15s
-      timeout: 3s
-      retries: 5
-      start_period: 10s
 
   # Platform server (NestJS) — internal only, UI will proxy
   platform-server:
@@ -80,7 +70,7 @@ services:
       platform-db:
         condition: service_healthy
       litellm:
-        condition: service_healthy
+        condition: service_started
       vault:
         condition: service_started
     expose:

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -87,7 +87,7 @@ services:
     expose:
       - "3010"
     # Run DB migrations then start the server. Requires prisma CLI in the image (now included).
-    command: ["/bin/sh", "-lc", "prisma migrate deploy command: ["/bin/sh", "-lc", "prisma migrate deploy # command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"]# command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"] tsx src/index.ts"]command: ["/bin/sh", "-lc", "prisma migrate deploy # command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"]# command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"] tsx src/index.ts"] tsx src/index.ts"]
+    command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"]
 
   # Platform UI reverse proxy — the only exposed service
   platform-ui:

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -76,7 +76,7 @@ services:
     expose:
       - "3010"
     # Run DB migrations then start the server. Requires prisma CLI in the image (now included).
-    command: ["/bin/sh", "-lc", "set -e; prisma migrate deploy --schema /opt/app/packages/platform-server/prisma/schema.prisma; exec tsx src/index.ts"]
+    command: ["/bin/sh", "-lc", "set -e; prisma migrate deploy --schema /opt/app/packages/platform-server/prisma/schema.prisma; exec node dist/index.js"]
 
   # Platform UI reverse proxy — the only exposed service
   platform-ui:

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -5,9 +5,9 @@ version: '3.9'
 
 services:
   # Postgres for Agents persistent state
-  agents-db:
+  agyn-db:
     image: postgres:16-alpine
-    container_name: agents-db
+    container_name: agyn-db
     restart: unless-stopped
     environment:
       POSTGRES_USER: agents
@@ -73,21 +73,21 @@ services:
     container_name: platform-server
     restart: unless-stopped
     environment:
-      AGENTS_DATABASE_URL: postgresql://agents:agents@agents-db:5432/agents
+      AGENTS_DATABASE_URL: postgresql://agents:agents@agyn-db:5432/agents
       LLM_PROVIDER: litellm
       LITELLM_BASE_URL: http://litellm:4000
       WORKSPACE_NETWORK_NAME: agents_stack
       CORS_ORIGINS: http://localhost:2496
       PORT: "3010"
     depends_on:
-      agents-db:
+      agyn-db:
         condition: service_healthy
       litellm:
         condition: service_healthy
     expose:
       - "3010"
     # Run DB migrations then start the server. Requires prisma CLI in the image (now included).
-    command: ["/bin/sh", "-lc", "prisma migrate deploy # command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"]# command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"] tsx src/index.ts"]
+    command: ["/bin/sh", "-lc", "prisma migrate deploy command: ["/bin/sh", "-lc", "prisma migrate deploy # command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"]# command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"] tsx src/index.ts"]command: ["/bin/sh", "-lc", "prisma migrate deploy # command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"]# command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"] tsx src/index.ts"] tsx src/index.ts"]
 
   # Platform UI reverse proxy — the only exposed service
   platform-ui:

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -65,7 +65,7 @@ services:
       PORT: "3010"
       VAULT_ENABLED: 'true'
       VAULT_ADDR: http://vault:8200
-      VAULT_TOKEN: dev-root
+      NODE_OPTIONS: --experimental-specifier-resolution=node
     depends_on:
       platform-db:
         condition: service_healthy

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -6,7 +6,6 @@ services:
   # Postgres for Agents persistent state
   agyn-db:
     image: postgres:16-alpine
-    container_name: agyn-db
     restart: unless-stopped
     environment:
       POSTGRES_USER: agents
@@ -23,7 +22,6 @@ services:
   # LiteLLM Postgres database
   litellm-db:
     image: postgres:16-alpine
-    container_name: litellm-db
     restart: unless-stopped
     environment:
       POSTGRES_DB: litellm
@@ -41,7 +39,6 @@ services:
   # LiteLLM service
   litellm:
     image: ghcr.io/berriai/litellm:v1.80.5-stable
-    container_name: litellm
     restart: unless-stopped
     environment:
       LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-dev-master-1234}
@@ -69,7 +66,6 @@ services:
   # Platform server (NestJS) — internal only, UI will proxy
   platform-server:
     image: ghcr.io/hautechai/agents-platform-server:latest
-    container_name: platform-server
     restart: unless-stopped
     environment:
       AGENTS_DATABASE_URL: postgresql://agents:agents@agyn-db:5432/agents
@@ -95,7 +91,6 @@ services:
   # Platform UI reverse proxy — the only exposed service
   platform-ui:
     image: ghcr.io/hautechai/agents-platform-ui:latest
-    container_name: platform-ui
     restart: unless-stopped
     environment:
       API_UPSTREAM: http://platform-server:3010
@@ -108,7 +103,6 @@ services:
 
   vault:
     image: hashicorp/vault:1.17
-    container_name: vault
 
     restart: unless-stopped
     cap_add:

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -76,7 +76,7 @@ services:
     expose:
       - "3010"
     # Run DB migrations then start the server. Requires prisma CLI in the image (now included).
-    command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"]
+    command: ["/bin/sh", "-lc", "prisma migrate deploy --schema /opt/app/packages/platform-server/prisma/schema.prisma prisma migrate deploy && tsx src/index.tsprisma migrate deploy && tsx src/index.ts tsx src/index.ts"]
 
   # Platform UI reverse proxy — the only exposed service
   platform-ui:

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -1,4 +1,3 @@
-
 # Isolated bootstrap compose to ship Agents platform to clients.
 # Includes all required dependencies and exposes a single port 2496 for the UI reverse proxy.
 
@@ -50,54 +49,18 @@ services:
       PORT: "4000"
       HOST: "0.0.0.0"
     depends_on:
-      platform-db:
+      litellm-db:
         condition: service_healthy
-      litellm:
-        condition: service_healthy
-      vault:
-        condition: service_started
-    expose:
-      - "3010"
-    # Run DB migrations then start the server. Requires prisma CLI in the image (now included).
-    command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"]
-  # Platform UI reverse proxy — the only exposed service
-  platform-ui:
-    image: ghcr.io/hautechai/agents-platform-ui:latest
-    restart: unless-stopped
-    environment:
-      API_UPSTREAM: http://platform-server:3010
-    depends_on:
-      platform-server:
-        condition: service_started
-    ports:
-      - "2496:80"
-
-
-  vault:
-    image: hashicorp/vault:1.17
-
-    restart: unless-stopped
-    cap_add:
-      - IPC_LOCK
-    environment: {}
-    command:
-      - server
-      - -dev
-      - -dev-root-token-id=dev-root
-      - -dev-listen-address=0.0.0.0:8200
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8200/v1/sys/health || (command -v curl >/dev/null 2>&1 && curl -fsS http://localhost:8200/v1/sys/health)"]
-      interval: 10s
+      test:
+        [
+          "CMD-SHELL",
+          "wget -qO- http://localhost:4000/health || wget -qO- http://localhost:4000/ui || wget -qO- http://localhost:4000/ || (command -v curl >/dev/null 2>&1 && curl -fsS http://localhost:4000/health)",
+        ]
+      interval: 15s
       timeout: 3s
       retries: 5
-
-networks:
-  agents_stack:
-    driver: bridge
-
-volumes:
-  agyn_pgdata:
-  litellm_pgdata:
+      start_period: 10s
 
   # Platform server (NestJS) — internal only, UI will proxy
   platform-server:
@@ -124,6 +87,7 @@ volumes:
       - "3010"
     # Run DB migrations then start the server. Requires prisma CLI in the image (now included).
     command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"]
+
   # Platform UI reverse proxy — the only exposed service
   platform-ui:
     image: ghcr.io/hautechai/agents-platform-ui:latest
@@ -136,10 +100,9 @@ volumes:
     ports:
       - "2496:80"
 
-
+  # HashiCorp Vault (dev mode) for secrets management — internal only
   vault:
     image: hashicorp/vault:1.17
-
     restart: unless-stopped
     cap_add:
       - IPC_LOCK

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -76,7 +76,7 @@ services:
     expose:
       - "3010"
     # Run DB migrations then start the server. Requires prisma CLI in the image (now included).
-    command: ["/bin/sh", "-lc", "set -e; prisma migrate deploy --schema /opt/app/packages/platform-server/prisma/schema.prisma; exec node dist/index.js"]
+    command: ["/bin/sh", "-lc", "set -e; prisma migrate deploy --schema /opt/app/packages/platform-server/prisma/schema.prisma; exec node --experimental-specifier-resolution=node dist/index.js"]
 
   # Platform UI reverse proxy — the only exposed service
   platform-ui:

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.9'
 
 # Isolated bootstrap compose to ship Agents platform to clients.
 # Includes all required dependencies and exposes a single port 2496 for the UI reverse proxy.

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -1,54 +1,111 @@
 version: '3.9'
 
-# Bootstrap compose to run the full Agents platform using pre-existing dependencies
-# from HautechAI/agents root docker-compose (agents_net network, vault, litellm, agents-db, etc.).
-# This file only orchestrates platform-server and platform-ui and exposes a single public port (2496).
-# Prerequisite: Start the dependencies compose from HautechAI/agents on the same host first.
+# Isolated bootstrap compose to ship Agents platform to clients.
+# Includes all required dependencies and exposes a single port 2496 for the UI reverse proxy.
 
 services:
+  # Postgres for Agents persistent state
+  agents-db:
+    image: postgres:16-alpine
+    container_name: agents-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: agents
+      POSTGRES_PASSWORD: agents
+      POSTGRES_DB: agents
+    volumes:
+      - agents_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U agents -d agents"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # LiteLLM Postgres database
+  litellm-db:
+    image: postgres:16-alpine
+    container_name: litellm-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: litellm
+      POSTGRES_USER: litellm
+      POSTGRES_PASSWORD: change-me
+    volumes:
+      - litellm_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U litellm -d litellm"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  # LiteLLM service
+  litellm:
+    image: ghcr.io/berriai/litellm:v1.80.5-stable
+    container_name: litellm
+    restart: unless-stopped
+    environment:
+      LITELLM_MASTER_KEY: ${LITELLM_MASTER_KEY:-sk-dev-master-1234}
+      LITELLM_SALT_KEY: ${LITELLM_SALT_KEY:-sk-dev-salt-1234}
+      DATABASE_URL: postgresql://litellm:change-me@litellm-db:5432/litellm
+      STORE_MODEL_IN_DB: "True"
+      UI_USERNAME: ${LITELLM_UI_USERNAME:-admin}
+      UI_PASSWORD: ${LITELLM_UI_PASSWORD:-admin}
+      PORT: "4000"
+      HOST: "0.0.0.0"
+    depends_on:
+      litellm-db:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -qO- http://localhost:4000/health || wget -qO- http://localhost:4000/ui || wget -qO- http://localhost:4000/ || (command -v curl >/dev/null 2>&1 && curl -fsS http://localhost:4000/health)",
+        ]
+      interval: 15s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+
+  # Platform server (NestJS) — internal only, UI will proxy
   platform-server:
     image: ghcr.io/hautechai/agents-platform-server:latest
     container_name: platform-server
     restart: unless-stopped
     environment:
-      # Required DB URL (agents-db must be running on the same docker network)
       AGENTS_DATABASE_URL: postgresql://agents:agents@agents-db:5432/agents
-      # LLM provider via LiteLLM (must be running on agents_net)
       LLM_PROVIDER: litellm
       LITELLM_BASE_URL: http://litellm:4000
-      # Optional Vault (if running)
-      VAULT_ENABLED: 'false'
-      VAULT_ADDR: http://vault:8200
-      VAULT_TOKEN: dev-root
-      # Workspace network name used by platform-server to attach sidecars
-      WORKSPACE_NETWORK_NAME: agents_net
-      # CORS for UI (served by platform-ui reverse proxy). Adjust if needed.
+      WORKSPACE_NETWORK_NAME: agents_stack
       CORS_ORIGINS: http://localhost:2496
-      # Service port in container (do not publish externally; UI proxies inbound traffic)
-      PORT: '3010'
-    networks:
-      - agents_net
-    # Keep internal only (UI handles external exposure).
+      PORT: "3010"
+    depends_on:
+      agents-db:
+        condition: service_healthy
+      litellm:
+        condition: service_healthy
     expose:
-      - '3010'
+      - "3010"
+    # NOTE: Once the server image includes Prisma CLI, uncomment the command below to run migrations before starting.
+    # command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"]
 
+  # Platform UI reverse proxy — the only exposed service
   platform-ui:
     image: ghcr.io/hautechai/agents-platform-ui:latest
     container_name: platform-ui
     restart: unless-stopped
     environment:
-      # UI reverse proxy target inside the docker network
       API_UPSTREAM: http://platform-server:3010
-    ports:
-      # Single external port for the UI reverse proxy
-      - '2496:80'
     depends_on:
-      - platform-server
-    networks:
-      - agents_net
+      platform-server:
+        condition: service_started
+    ports:
+      - "2496:80"
 
 networks:
-  # Reuse the shared network created by the HautechAI/agents root compose
-  agents_net:
-    external: true
-    name: agents_net
+  agents_stack:
+    driver: bridge
+
+volumes:
+  agents_pgdata:
+  litellm_pgdata:

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -77,9 +77,31 @@ services:
       - "3010"
     # Run DB migrations then start the server. Requires prisma CLI in the image (now included).
     command: ["/bin/sh", "-lc", "set -e; prisma migrate deploy --schema /opt/app/packages/platform-server/prisma/schema.prisma; exec tsx src/index.ts"]
-      interval: 10s
-      timeout: 3s
-      retries: 5
+
+  # Platform UI reverse proxy — the only exposed service
+  platform-ui:
+    image: ghcr.io/hautechai/agents-platform-ui:latest
+    restart: unless-stopped
+    environment:
+      API_UPSTREAM: http://platform-server:3010
+    depends_on:
+      platform-server:
+        condition: service_started
+    ports:
+      - "2496:80"
+
+  # HashiCorp Vault (dev mode) for secrets management — internal only
+  vault:
+    image: hashicorp/vault:1.17
+    restart: unless-stopped
+    cap_add:
+      - IPC_LOCK
+    environment: {}
+    command:
+      - server
+      - -dev
+      - -dev-root-token-id=dev-root
+      - -dev-listen-address=0.0.0.0:8200
 
 networks:
   agents_stack:

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -1,0 +1,54 @@
+version: '3.9'
+
+# Bootstrap compose to run the full Agents platform using pre-existing dependencies
+# from HautechAI/agents root docker-compose (agents_net network, vault, litellm, agents-db, etc.).
+# This file only orchestrates platform-server and platform-ui and exposes a single public port (2496).
+# Prerequisite: Start the dependencies compose from HautechAI/agents on the same host first.
+
+services:
+  platform-server:
+    image: ghcr.io/hautechai/agents-platform-server:latest
+    container_name: platform-server
+    restart: unless-stopped
+    environment:
+      # Required DB URL (agents-db must be running on the same docker network)
+      AGENTS_DATABASE_URL: postgresql://agents:agents@agents-db:5432/agents
+      # LLM provider via LiteLLM (must be running on agents_net)
+      LLM_PROVIDER: litellm
+      LITELLM_BASE_URL: http://litellm:4000
+      # Optional Vault (if running)
+      VAULT_ENABLED: 'false'
+      VAULT_ADDR: http://vault:8200
+      VAULT_TOKEN: dev-root
+      # Workspace network name used by platform-server to attach sidecars
+      WORKSPACE_NETWORK_NAME: agents_net
+      # CORS for UI (served by platform-ui reverse proxy). Adjust if needed.
+      CORS_ORIGINS: http://localhost:2496
+      # Service port in container (do not publish externally; UI proxies inbound traffic)
+      PORT: '3010'
+    networks:
+      - agents_net
+    # Keep internal only (UI handles external exposure).
+    expose:
+      - '3010'
+
+  platform-ui:
+    image: ghcr.io/hautechai/agents-platform-ui:latest
+    container_name: platform-ui
+    restart: unless-stopped
+    environment:
+      # UI reverse proxy target inside the docker network
+      API_UPSTREAM: http://platform-server:3010
+    ports:
+      # Single external port for the UI reverse proxy
+      - '2496:80'
+    depends_on:
+      - platform-server
+    networks:
+      - agents_net
+
+networks:
+  # Reuse the shared network created by the HautechAI/agents root compose
+  agents_net:
+    external: true
+    name: agents_net

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -4,7 +4,7 @@
 
 services:
   # Postgres for Agents persistent state
-  agyn-db:
+  platform-db:
     image: postgres:16-alpine
     restart: unless-stopped
     environment:
@@ -50,25 +50,61 @@ services:
       PORT: "4000"
       HOST: "0.0.0.0"
     depends_on:
-      litellm-db:
+      platform-db:
         condition: service_healthy
+      litellm:
+        condition: service_healthy
+      vault:
+        condition: service_started
+    expose:
+      - "3010"
+    # Run DB migrations then start the server. Requires prisma CLI in the image (now included).
+    command: ["/bin/sh", "-lc", "prisma migrate deploy && tsx src/index.ts"]
+  # Platform UI reverse proxy — the only exposed service
+  platform-ui:
+    image: ghcr.io/hautechai/agents-platform-ui:latest
+    restart: unless-stopped
+    environment:
+      API_UPSTREAM: http://platform-server:3010
+    depends_on:
+      platform-server:
+        condition: service_started
+    ports:
+      - "2496:80"
+
+
+  vault:
+    image: hashicorp/vault:1.17
+
+    restart: unless-stopped
+    cap_add:
+      - IPC_LOCK
+    environment: {}
+    command:
+      - server
+      - -dev
+      - -dev-root-token-id=dev-root
+      - -dev-listen-address=0.0.0.0:8200
     healthcheck:
-      test:
-        [
-          "CMD-SHELL",
-          "wget -qO- http://localhost:4000/health || wget -qO- http://localhost:4000/ui || wget -qO- http://localhost:4000/ || (command -v curl >/dev/null 2>&1 && curl -fsS http://localhost:4000/health)",
-        ]
-      interval: 15s
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8200/v1/sys/health || (command -v curl >/dev/null 2>&1 && curl -fsS http://localhost:8200/v1/sys/health)"]
+      interval: 10s
       timeout: 3s
       retries: 5
-      start_period: 10s
+
+networks:
+  agents_stack:
+    driver: bridge
+
+volumes:
+  agyn_pgdata:
+  litellm_pgdata:
 
   # Platform server (NestJS) — internal only, UI will proxy
   platform-server:
     image: ghcr.io/hautechai/agents-platform-server:latest
     restart: unless-stopped
     environment:
-      AGENTS_DATABASE_URL: postgresql://agents:agents@agyn-db:5432/agents
+      AGENTS_DATABASE_URL: postgresql://agents:agents@platform-db:5432/agents
       LLM_PROVIDER: litellm
       LITELLM_BASE_URL: http://litellm:4000
       WORKSPACE_NETWORK_NAME: agents_stack
@@ -78,7 +114,7 @@ services:
       VAULT_ADDR: http://vault:8200
       VAULT_TOKEN: dev-root
     depends_on:
-      agyn-db:
+      platform-db:
         condition: service_healthy
       litellm:
         condition: service_healthy


### PR DESCRIPTION
Implements /agyn/docker-compose.yaml to run the Agents platform using GHCR images and the shared external network from HautechAI/agents dependencies compose:

- platform-server (internal on :3010), connected to agents-db and LiteLLM via agents_net
- platform-ui reverse proxy exposed on host :2496, proxying /api and /socket.io to platform-server
- Reuses external network agents_net created by HautechAI/agents root compose; start dependencies on that network first.

Issue: https://github.com/agynio/bootstrap/issues/1
