### PR TITLE
feat(compose): mount docker.sock and graph directory; set GRAPH_REPO_PATH

### DIFF
--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -72,6 +72,11 @@ services:
       VAULT_ENABLED: 'true'
       VAULT_ADDR: http://vault:8200
       VAULT_TOKEN: dev-root
+      GRAPH_REPO_PATH: /opt/app/data/graph
+      GRAPH_BRANCH: graph-state
+      GRAPH_AUTHOR_NAME: Agyn Platform
+      GRAPH_AUTHOR_EMAIL: rowan.stein@agyn.io
+      DOCKER_SOCKET: /var/run/docker.sock
     depends_on:
       platform-db:
         condition: service_healthy
@@ -83,6 +88,9 @@ services:
       - "3010"
     # Run DB migrations then start the server. Requires prisma CLI in the image (now included).
     command: ["/bin/sh", "-lc", "set -e; prisma migrate deploy --schema /opt/app/packages/platform-server/prisma/schema.prisma; exec tsx src/index.ts"]
+    volumes:
+      - ../graph:/opt/app/data/graph
+      - /var/run/docker.sock:/var/run/docker.sock
     networks:
       - agents_stack
 


### PR DESCRIPTION
This updates the bootstrap compose to:

- Mount /var/run/docker.sock into platform-server for Docker events and workspace ops
- Mount ./graph from repo into /opt/app/data/graph (persistent git-backed graph repo)
- Set GRAPH_REPO_PATH and recommended graph-related env (branch, author)

Note: platform-server needs git in the runtime image to initialize and commit graph changes. We will open a companion PR in HautechAI/agents to add git to the runtime image if it’s not present yet.
