### PR TITLE
fix(compose): add group_add for docker.sock perms

### DIFF
--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -72,6 +72,11 @@ services:
       VAULT_ENABLED: 'true'
       VAULT_ADDR: http://vault:8200
       VAULT_TOKEN: dev-root
+      GRAPH_REPO_PATH: /opt/app/data/graph
+      GRAPH_BRANCH: graph-state
+      GRAPH_AUTHOR_NAME: Agyn Platform
+      GRAPH_AUTHOR_EMAIL: rowan.stein@agyn.io
+      DOCKER_SOCKET: /var/run/docker.sock
     depends_on:
       platform-db:
         condition: service_healthy
@@ -83,6 +88,9 @@ services:
       - "3010"
     # Run DB migrations then start the server. Requires prisma CLI in the image (now included).
     command: ["/bin/sh", "-lc", "set -e; prisma migrate deploy --schema /opt/app/packages/platform-server/prisma/schema.prisma; exec tsx src/index.ts"]
+    volumes:
+      - ../graph:/opt/app/data/graph
+      - /var/run/docker.sock:/var/run/docker.sock
     networks:
       - agents_stack
 

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -91,6 +91,8 @@ services:
     volumes:
       - ../graph:/opt/app/data/graph
       - /var/run/docker.sock:/var/run/docker.sock
+    group_add:
+      - "${DOCKER_HOST_GID}"
     networks:
       - agents_stack
 


### PR DESCRIPTION
Add group_add with ${DOCKER_HOST_GID} to allow non-root container to access /var/run/docker.sock. Usage:\n\nexport DOCKER_HOST_GID=$(stat -c '%g' /var/run/docker.sock)\n\ndocker compose -f agyn/docker-compose.yaml up -d\n\nAlternative quick fix: set user: "root" for platform-server in compose (less secure).