### PR TITLE
chore: bump platform images to 0.9.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "graph"]
 	path = graph
-	url = https://github.com/HautechAI/agents-graph.git
+	url = https://github.com/agynio/graph.git

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -63,7 +63,7 @@ services:
   # Platform server (NestJS) — internal only, UI will proxy
   platform-server:
     user: root
-    image: ghcr.io/agynio/platform-server:latest
+    image: ghcr.io/agynio/platform-server:0.9.0
     restart: unless-stopped
     environment:
       AGENTS_DATABASE_URL: postgresql://agents:agents@platform-db:5432/agents
@@ -100,7 +100,7 @@ services:
 
   # Platform UI reverse proxy — the only exposed service
   platform-ui:
-    image: ghcr.io/agynio/platform-ui:latest
+    image: ghcr.io/agynio/platform-ui:0.9.0
     restart: unless-stopped
     environment:
       API_UPSTREAM: http://platform-server:3010


### PR DESCRIPTION
## Why
Platform **v0.9.0** has been released, so bootstrap should reference the corresponding images.

## What changed
- Pin platform images in `agyn/docker-compose.yaml`:
  - `ghcr.io/agynio/platform-server:0.9.0`
  - `ghcr.io/agynio/platform-ui:0.9.0`

## Related
- Issue: #9
- Platform release: https://github.com/agynio/platform/releases/tag/v0.9.0
