### PR TITLE
chore: bump platform images to 0.9.1

### DIFF
--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -63,7 +63,7 @@ services:
   # Platform server (NestJS) — internal only, UI will proxy
   platform-server:
     user: root
-    image: ghcr.io/agynio/platform-server:0.9.0
+    image: ghcr.io/agynio/platform-server:0.9.1
     restart: unless-stopped
     environment:
       AGENTS_DATABASE_URL: postgresql://agents:agents@platform-db:5432/agents
@@ -100,7 +100,7 @@ services:
 
   # Platform UI reverse proxy — the only exposed service
   platform-ui:
-    image: ghcr.io/agynio/platform-ui:0.9.0
+    image: ghcr.io/agynio/platform-ui:0.9.1
     restart: unless-stopped
     environment:
       API_UPSTREAM: http://platform-server:3010


### PR DESCRIPTION
## Summary
Bumps `agynio/platform` image tags used by bootstrap to **0.9.1**.

## Context
`agynio/platform` patch release: https://github.com/agynio/platform/releases/tag/v0.9.1

## Changes
- Update `ghcr.io/agynio/platform-server` from `0.9.0` → `0.9.1`
- Update `ghcr.io/agynio/platform-ui` from `0.9.0` → `0.9.1`

## Notes
This release includes the Git LFS checkout fix so assets (e.g. MP3s) are present in built images.
