### PR TITLE
chore: bump platform image tags

### DIFF
--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -63,7 +63,7 @@ services:
   # Platform server (NestJS) — internal only, UI will proxy
   platform-server:
     user: root
-    image: ghcr.io/agynio/platform-server:0.9.1
+    image: ghcr.io/agynio/platform-server:0.10.0
     restart: unless-stopped
     environment:
       AGENTS_DATABASE_URL: postgresql://agents:agents@platform-db:5432/agents
@@ -100,7 +100,7 @@ services:
 
   # Platform UI reverse proxy — the only exposed service
   platform-ui:
-    image: ghcr.io/agynio/platform-ui:0.9.1
+    image: ghcr.io/agynio/platform-ui:0.10.0
     restart: unless-stopped
     environment:
       API_UPSTREAM: http://platform-server:3010


### PR DESCRIPTION
## Summary
- update platform server and UI image tags to 0.10.0 following the new release
- no other compose changes required

## Testing
- docker-compose -f agyn/docker-compose.yaml config
