### PR TITLE
revert: remove platform-ui vite base arg

### DIFF
--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -101,10 +101,6 @@ services:
   # Platform UI reverse proxy — the only exposed service
   platform-ui:
     image: ghcr.io/agynio/platform-ui:0.10.0
-    build:
-      context: "${PLATFORM_UI_BUILD_CONTEXT:-https://github.com/agynio/platform.git#v0.10.0:packages/platform-ui}"
-      args:
-        VITE_API_BASE_URL: "${PLATFORM_UI_VITE_API_BASE_URL:-http://localhost:2496}"
     restart: unless-stopped
     environment:
       API_UPSTREAM: http://platform-server:3010


### PR DESCRIPTION
## Summary
- revert commit 516b31b (fix(compose): set vite api base arg) to restore original compose behavior per #16

## Testing
- docker compose -f agyn/docker-compose.yaml config *(fails: docker compose plugin unavailable in environment; cannot run locally)*
