### PR TITLE
docs: add README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # bootstrap
+
+## Quickstart
+
+Prereqs: Docker with Compose v2 enabled.
+
+```bash
+git clone --recurse-submodules https://github.com/agynio/bootstrap.git
+cd bootstrap/agyn
+docker compose up -d
+```
+
+Open http://localhost:2496 in your browser.
+
+> Note: `agyn/docker-compose.yaml` is the compose file, and the `graph` submodule is required.


### PR DESCRIPTION
## Summary
- add a copy-pasteable quickstart with Docker Compose v2
- note the compose file path and graph submodule requirement

## Testing
- Not run (docs-only change) 

Closes #18.