### PR TITLE
chore: bump platform images to 0.11.0

### DIFF
--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -63,7 +63,7 @@ services:
   # Platform server (NestJS) — internal only, UI will proxy
   platform-server:
     user: root
-    image: ghcr.io/agynio/platform-server:0.10.0
+    image: ghcr.io/agynio/platform-server:0.11.0
     restart: unless-stopped
     environment:
       AGENTS_DATABASE_URL: postgresql://agents:agents@platform-db:5432/agents
@@ -100,7 +100,7 @@ services:
 
   # Platform UI reverse proxy — the only exposed service
   platform-ui:
-    image: ghcr.io/agynio/platform-ui:0.10.0
+    image: ghcr.io/agynio/platform-ui:0.11.0
     restart: unless-stopped
     environment:
       API_UPSTREAM: http://platform-server:3010


### PR DESCRIPTION
Resolves #22

## Summary
- bump platform-server image to v0.11.0
- bump platform-ui image to v0.11.0
- confirmed no other platform image tags need updates

## Testing
- docker compose -f agyn/docker-compose.yaml config *(fails: docker compose plugin missing, unknown shorthand flag: 'f')*
- docker-compose -f agyn/docker-compose.yaml config *(fails: docker-compose command not found)*