### PR TITLE
Add registry mirror pull-through cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,38 @@ Open http://localhost:2496 in your browser.
 > Notes:
 > - `agyn/docker-compose.yaml` is the compose file, and the `graph` submodule is required.
 > - The stack now includes the `docker-runner` service, which brokers privileged Docker access for the platform-server. Ensure the host socket is available. The default shared secret is `change-me`; override `DOCKER_RUNNER_SHARED_SECRET` in `agyn/.env` for shared deployments.
+
+## Docker registry mirror
+
+Bootstrap now ships a pull-through Docker registry cache (`registry-mirror` service) backed by `registry:2` in proxy mode. The service stays on the internal `agents_stack` network by default and is only used when the host Docker daemon points at it.
+
+1. **Opt-in loopback publish (optional):**
+   ```bash
+   cp agyn/docker-compose.override.yaml.example agyn/docker-compose.override.yaml
+   cd agyn
+   docker compose up -d registry-mirror
+   ```
+   This publishes `127.0.0.1:5000->5000` while leaving other services unchanged. Remove the override to return to internal-only operation.
+
+2. **Configure the host Docker daemon (`/etc/docker/daemon.json`):**
+   ```json
+   {
+     "registry-mirrors": ["http://127.0.0.1:5000"]
+   }
+   ```
+   Restart Docker afterwards (e.g. `sudo systemctl restart docker`). This is required because bootstrap services reuse the host Docker socket.
+
+3. **Containerd note:** if you run containerd directly, add the mirror endpoint to `/etc/containerd/config.toml` and restart containerd:
+   ```toml
+   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+     endpoint = ["http://127.0.0.1:5000"]
+   ```
+
+4. **Validate the mirror:**
+   - `docker compose ps registry-mirror` should show `healthy` once the service starts.
+   - `curl -fsSL http://127.0.0.1:5000/v2/` returns `{}`.
+   - Pull an image twice (e.g. `docker pull alpine:3.19` twice) and observe `docker compose logs -f registry-mirror` showing cache hits on the second run.
+
+5. **Rollback:** stop the service (`docker compose down registry-mirror`), remove the loopback override, delete the mirror entry from `daemon.json`/containerd config, and restart Docker/containerd. Existing pulls will then bypass the cache again.
+
+> The mirror only accelerates pulls when the host daemon is configured as above. Containers inside the stack do not access it directly otherwise.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,6 @@ Bootstrap now ships a pull-through Docker registry cache (`registry-mirror` serv
    - `curl -fsSL http://127.0.0.1:5000/v2/` returns `{}`.
    - Pull an image twice (e.g. `docker pull alpine:3.19` twice) and observe `docker compose logs -f registry-mirror` showing cache hits on the second run.
 
-5. **Rollback:** stop the service (`docker compose down registry-mirror`), remove the loopback override, delete the mirror entry from `daemon.json`/containerd config, and restart Docker/containerd. Existing pulls will then bypass the cache again.
+5. **Rollback:** stop the service (`docker compose stop registry-mirror && docker compose rm -f registry-mirror`), remove the loopback override, delete the mirror entry from `daemon.json`/containerd config, and restart Docker/containerd. Existing pulls will then bypass the cache again.
 
 > The mirror only accelerates pulls when the host daemon is configured as above. Containers inside the stack do not access it directly otherwise.

--- a/agyn/docker-compose.override.yaml.example
+++ b/agyn/docker-compose.override.yaml.example
@@ -1,0 +1,6 @@
+# Optional override to expose the registry mirror on the host loopback
+# Copy to agyn/docker-compose.override.yaml to enable
+services:
+  registry-mirror:
+    ports:
+      - "127.0.0.1:5000:5000"

--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -73,6 +73,21 @@ services:
     networks:
       - agents_stack
 
+  registry-mirror:
+    image: registry:2
+    restart: unless-stopped
+    volumes:
+      - registry-cache:/var/lib/registry
+      - ./registry:/etc/docker/registry:ro
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:5000/v2/"]
+      interval: 30s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+    networks:
+      - agents_stack
+
   # Platform server (NestJS) — internal only, UI will proxy
   platform-server:
     user: root
@@ -179,3 +194,4 @@ volumes:
   agyn_pgdata:
   litellm_pgdata:
   vault-file:
+  registry-cache:

--- a/agyn/registry/config.yml
+++ b/agyn/registry/config.yml
@@ -1,0 +1,17 @@
+version: 0.1
+
+log:
+  fields:
+    service: registry
+
+storage:
+  filesystem:
+    rootdirectory: /var/lib/registry
+  delete:
+    enabled: true
+
+http:
+  addr: 0.0.0.0:5000
+
+proxy:
+  remoteurl: https://registry-1.docker.io


### PR DESCRIPTION
## Summary
- add registry mirror config, service, and persistent cache volume
- provide an override template to publish 127.0.0.1:5000 when desired
- document the host daemon setup, validation steps, and rollback guidance

## Testing
- docker compose config
- docker compose up -d registry-mirror && docker compose ps registry-mirror

Closes #27