### PR TITLE
chore: bump platform images to 0.13.2

### DIFF
--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
       - agents_stack
 
   docker-runner:
-    image: ghcr.io/agynio/docker-runner:0.13.1
+    image: ghcr.io/agynio/docker-runner:0.13.2
     restart: unless-stopped
     environment:
       DOCKER_RUNNER_HOST: "0.0.0.0"
@@ -87,7 +87,7 @@ services:
   # Platform server (NestJS) — internal only, UI will proxy
   platform-server:
     user: root
-    image: ghcr.io/agynio/platform-server:0.13.1
+    image: ghcr.io/agynio/platform-server:0.13.2
     restart: unless-stopped
     environment:
       AGENTS_DATABASE_URL: postgresql://agents:agents@platform-db:5432/agents
@@ -127,7 +127,7 @@ services:
 
   # Platform UI reverse proxy — the only exposed service
   platform-ui:
-    image: ghcr.io/agynio/platform-ui:0.13.1
+    image: ghcr.io/agynio/platform-ui:0.13.2
     restart: unless-stopped
     environment:
       API_UPSTREAM: http://platform-server:3010


### PR DESCRIPTION
## Summary
- bump docker-runner, platform-server, and platform-ui images to 0.13.2
- revalidated the bootstrap compose stack with config/pull/up

Fixes #32

## Validation
- docker compose -f agyn/docker-compose.yaml config
  <details>
  <summary>Output</summary>

  ```
$(cat /tmp/validation-config.txt)
  ```
  </details>
- docker compose -f agyn/docker-compose.yaml pull
  <details>
  <summary>Output</summary>

  ```
$(cat /tmp/validation-pull.txt)
  ```
  </details>
- docker compose -f agyn/docker-compose.yaml up -d
  <details>
  <summary>Output</summary>

  ```
$(cat /tmp/validation-up.txt)
  ```
  </details>