### PR TITLE
Bump platform images to 0.14.4

### DIFF
--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
       - agents_stack
 
   docker-runner:
-    image: ghcr.io/agynio/docker-runner:0.13.2
+    image: ghcr.io/agynio/docker-runner:0.14.4
     restart: unless-stopped
     environment:
       DOCKER_RUNNER_HOST: "0.0.0.0"
@@ -89,7 +89,7 @@ services:
   # Platform server (NestJS) — internal only, UI will proxy
   platform-server:
     user: root
-    image: ghcr.io/agynio/platform-server:0.13.2
+    image: ghcr.io/agynio/platform-server:0.14.4
     restart: unless-stopped
     environment:
       AGENTS_DATABASE_URL: postgresql://agents:agents@platform-db:5432/agents
@@ -129,7 +129,7 @@ services:
 
   # Platform UI reverse proxy — the only exposed service
   platform-ui:
-    image: ghcr.io/agynio/platform-ui:0.13.2
+    image: ghcr.io/agynio/platform-ui:0.14.4
     restart: unless-stopped
     environment:
       API_UPSTREAM: http://platform-server:3010


### PR DESCRIPTION
Closes #34

## Summary
- Bumped platform image tags in `agyn/docker-compose.yaml` from `0.13.2` to `0.14.4` for:
  - `ghcr.io/agynio/docker-runner`
  - `ghcr.io/agynio/platform-server`
  - `ghcr.io/agynio/platform-ui`

## Smoke test results (local)
Executed from `/workspace/bootstrap/agyn`:
- `docker compose pull`
- `docker compose up -d`
- `docker compose ps`
- `docker compose logs --tail=200 platform-server platform-ui docker-runner`
- `curl -fsS http://localhost:2496/ >/dev/null`
- `docker compose exec platform-ui wget -qO- http://platform-server:3010/health || true`
- `docker compose exec platform-ui wget -qO- http://docker-runner:7071/health || true`

Observed results:
- Image pulls succeeded for all services, including `0.14.4` artifacts.
- Stack started successfully and services remained up (`platform-server` reached `healthy`).
- UI endpoint check succeeded (`curl` exited 0 for `http://localhost:2496/`).
- `platform-server` health check from `platform-ui` initially returned connection refused during startup, then server became healthy.
- `docker-runner` health endpoint returned `401 Unauthorized` from `platform-ui` (service reachable, auth enforced).

Conclusion: **Smoke tests passed locally**.

## Notes
- `platform-server` logs include expected warnings about docker socket permissions inside this environment (`connect EACCES /var/run/docker.sock`) from background docker-runner connectivity checks; this did not block service startup or UI reachability for smoke validation.