### PR TITLE
Bump platform-ui to 0.14.5 (fix terminal WebSocket issue)

### DIFF
--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -129,7 +129,7 @@ services:
 
   # Platform UI reverse proxy — the only exposed service
   platform-ui:
-    image: ghcr.io/agynio/platform-ui:0.14.4
+    image: ghcr.io/agynio/platform-ui:0.14.5
     restart: unless-stopped
     environment:
       API_UPSTREAM: http://platform-server:3010


### PR DESCRIPTION
This PR bumps the `platform-ui` image tag to **0.14.5** to include the nginx fix enabling WebSocket upgrade for the terminal endpoint.

Related platform issue: https://github.com/agynio/platform/issues/1337
Related platform PR: https://github.com/agynio/platform/pull/1338
Release: https://github.com/agynio/platform/releases/tag/v0.14.5

Change:
- `agyn/docker-compose.yaml` — `ghcr.io/agynio/platform-ui:0.14.4` → `ghcr.io/agynio/platform-ui:0.14.5`

Effect:
- Prebuilt deployments using bootstrap will receive the fixed UI proxy config so terminal WS handshake to `/api/containers/{id}/terminal/ws?...` succeeds.

After merge:
- Pull updated images and restart the stack. Confirm terminal sessions are interactive over WS.