### PR TITLE
chore: bump platform images to 0.15.2

### DIFF
--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -61,7 +61,7 @@ services:
       - agents_stack
 
   docker-runner:
-    image: ghcr.io/agynio/docker-runner:0.15.1
+    image: ghcr.io/agynio/docker-runner:0.15.2
     restart: unless-stopped
     environment:
       DOCKER_RUNNER_HOST: "0.0.0.0"
@@ -89,7 +89,7 @@ services:
   # Platform server (NestJS) — internal only, UI will proxy
   platform-server:
     user: root
-    image: ghcr.io/agynio/platform-server:0.15.1
+    image: ghcr.io/agynio/platform-server:0.15.2
     restart: unless-stopped
     environment:
       AGENTS_DATABASE_URL: postgresql://agents:agents@platform-db:5432/agents
@@ -129,7 +129,7 @@ services:
 
   # Platform UI reverse proxy — the only exposed service
   platform-ui:
-    image: ghcr.io/agynio/platform-ui:0.15.1
+    image: ghcr.io/agynio/platform-ui:0.15.2
     restart: unless-stopped
     environment:
       API_UPSTREAM: http://platform-server:3010


### PR DESCRIPTION
Updates image tags in agyn/docker-compose.yaml to 0.15.2 for:
- ghcr.io/agynio/docker-runner
- ghcr.io/agynio/platform-server
- ghcr.io/agynio/platform-ui

Release v0.15.2 in agynio/platform contains the DinD ulimit fix from PR #1344.