### PR TITLE
chore: bump platform images to v0.16.1

### DIFF
--- a/agyn/docker-compose.yaml
+++ b/agyn/docker-compose.yaml
@@ -89,7 +89,7 @@ services:
   # Platform server (NestJS) — internal only, UI will proxy
   platform-server:
     user: root
-    image: ghcr.io/agynio/platform-server:0.16.0
+    image: ghcr.io/agynio/platform-server:0.16.1
     restart: unless-stopped
     environment:
       AGENTS_DATABASE_URL: postgresql://agents:agents@platform-db:5432/agents
@@ -129,7 +129,7 @@ services:
 
   # Platform UI reverse proxy — the only exposed service
   platform-ui:
-    image: ghcr.io/agynio/platform-ui:0.16.0
+    image: ghcr.io/agynio/platform-ui:0.16.1
     restart: unless-stopped
     environment:
       API_UPSTREAM: http://platform-server:3010


### PR DESCRIPTION
Bump Platform image tags to v0.16.1:
- ghcr.io/agynio/platform-server:0.16.1
- ghcr.io/agynio/platform-ui:0.16.1

Platform release notes: https://github.com/agynio/platform/releases/tag/v0.16.1

Includes MCP tool error handling improvements (plain-text error format, no stack traces, preserved tool error text).